### PR TITLE
Implement Tool and Category management features with exception handli…

### DIFF
--- a/src/main/java/com/codeflow/toolflow/controller/category/CategoryController.java
+++ b/src/main/java/com/codeflow/toolflow/controller/category/CategoryController.java
@@ -1,0 +1,42 @@
+package com.codeflow.toolflow.controller.category;
+
+import com.codeflow.toolflow.dto.ApiError;
+import com.codeflow.toolflow.dto.category.CategoryResponse;
+import com.codeflow.toolflow.persistence.category.entity.Category;
+import com.codeflow.toolflow.service.category.CategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/categories")
+public class CategoryController {
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMINISTRATOR', 'TOOL_ADMINISTRATOR')")
+    @Operation(
+            summary = "Get All Categories",
+            description = "Returns a list of all available categories in the system."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Categories retrieved successfully",
+                    content = @Content(schema = @Schema(implementation = CategoryResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Internal server error",
+                    content = @Content(schema = @Schema(implementation = ApiError.class)))
+    })
+    public ResponseEntity<List<CategoryResponse>> getAllCategories() {
+        List<CategoryResponse> categories = categoryService.getAll();
+        return ResponseEntity.ok(categories);
+    }
+}

--- a/src/main/java/com/codeflow/toolflow/controller/tool/ToolController.java
+++ b/src/main/java/com/codeflow/toolflow/controller/tool/ToolController.java
@@ -1,0 +1,177 @@
+package com.codeflow.toolflow.controller.tool;
+
+import com.codeflow.toolflow.dto.ApiError;
+import com.codeflow.toolflow.dto.tool.ToolRequest;
+import com.codeflow.toolflow.dto.tool.ToolResponse;
+import com.codeflow.toolflow.dto.tool.ToolStockRequest;
+import com.codeflow.toolflow.service.tool.ToolService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * REST controller for managing tool operations.
+ */
+@RestController
+@RequestMapping("/tools")
+public class ToolController {
+
+    @Autowired
+    private ToolService toolService;
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('ADMINISTRATOR', 'TOOL_ADMINISTRATOR')")
+    @Operation(
+            summary = "Register New Tool",
+            description = "Creates a new tool with the provided tool details.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Tool registration payload. Contains data such as name, brand, quantity, availability, damaged, onLoan, consumable, etc.",
+                    content = @Content(schema = @Schema(implementation = ToolRequest.class))
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Tool successfully created", content = @Content(schema = @Schema(implementation = ToolResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid input", content = @Content(schema = @Schema(implementation = ApiError.class)))
+    })
+    public ResponseEntity<ToolResponse> registerOne(@Valid @RequestBody ToolRequest toolRequest) {
+        ToolResponse response = toolService.registerOneTool(toolRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMINISTRATOR', 'TOOL_ADMINISTRATOR')")
+    @Operation(
+            summary = "Update Tool",
+            description = "Updates an existing tool using the provided details.",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "id", description = "ID of the tool to be updated", required = true)
+            },
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Tool update payload.",
+                    content = @Content(schema = @Schema(implementation = ToolRequest.class))
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Tool successfully updated", content = @Content(schema = @Schema(implementation = ToolResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid input", content = @Content(schema = @Schema(implementation = ApiError.class))),
+            @ApiResponse(responseCode = "404", description = "Tool not found", content = @Content(schema = @Schema(implementation = ApiError.class)))
+    })
+    public ResponseEntity<ToolResponse> updateOne(@PathVariable Long id, @Valid @RequestBody ToolRequest toolRequest) {
+        ToolResponse response = toolService.updateOneTool(id, toolRequest);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMINISTRATOR', 'TOOL_ADMINISTRATOR')")
+    @Operation(
+            summary = "Delete Tool",
+            description = "Deletes (soft) a tool by marking its status as false.",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "id", description = "ID of the tool to be deleted", required = true)
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Tool successfully deleted"),
+            @ApiResponse(responseCode = "400", description = "Invalid ID", content = @Content(schema = @Schema(implementation = ApiError.class))),
+            @ApiResponse(responseCode = "404", description = "Tool not found", content = @Content(schema = @Schema(implementation = ApiError.class)))
+    })
+    public ResponseEntity<Void> deleteOne(@PathVariable Long id) {
+        toolService.deleteOneTool(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMINISTRATOR', 'TOOL_ADMINISTRATOR')")
+    @Operation(
+            summary = "Get Paginated Tools",
+            description = "Retrieves a paginated list of tools. Supports filtering by name and multiple categories.",
+            parameters = {
+                    @Parameter(name = "page", in = ParameterIn.QUERY, description = "Page number", example = "0"),
+                    @Parameter(name = "size", in = ParameterIn.QUERY, description = "Page size", example = "10"),
+                    @Parameter(name = "sort", in = ParameterIn.QUERY, description = "Sort format: property,asc|desc", example = "toolName,asc"),
+                    @Parameter(
+                            name = "filter",
+                            in = ParameterIn.QUERY,
+                            description = "Filter criteria in the format `field:value1,value2`. " +
+                                    "Can be repeated for multiple filters. Examples: " +
+                                    "`toolName:Drill`, `brand:Bosch`, `category.name:Hand Tools,Power Tools`.",
+                            examples = {
+                                    @ExampleObject(name = "Single value", value = "toolName:Drill"),
+                                    @ExampleObject(name = "Multiple values", value = "category.name:Hand Tools,Power Tools"),
+                                    @ExampleObject(name = "Combined filters", value = "toolName:Drill&filter=brand:Bosch")
+                            }
+                    )
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Tools retrieved successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = Page.class)
+                    )),
+            @ApiResponse(responseCode = "500", description = "Internal server error",
+                    content = @Content(schema = @Schema(implementation = ApiError.class)))
+    })
+    public ResponseEntity<Page<ToolResponse>> getPage(
+            @PageableDefault(sort = "toolName", direction = Sort.Direction.ASC) Pageable pageable,
+            @RequestParam(value = "filter", required = false) List<String> filters) {
+
+        return ResponseEntity.ok(toolService.getPage(pageable, filters));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMINISTRATOR', 'TOOL_ADMINISTRATOR')")
+    @Operation(
+            summary = "Get Tool by ID",
+            description = "Fetches a tool using its unique identifier.",
+            parameters = {
+                    @Parameter(name = "id", in = ParameterIn.PATH, description = "Tool ID", required = true)
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Tool retrieved successfully", content = @Content(schema = @Schema(implementation = ToolResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Tool not found", content = @Content(schema = @Schema(implementation = ApiError.class)))
+    })
+    public ResponseEntity<ToolResponse> getOne(@PathVariable Long id) {
+        return ResponseEntity.ok(toolService.getOne(id));
+    }
+
+    @PutMapping("/stock/{id}")
+    @PreAuthorize("hasAnyRole('ADMINISTRATOR', 'TOOL_ADMINISTRATOR')")
+    @Operation(
+            summary = "Update Tool Stock",
+            description = "Updates only stock-related fields (quantity, available, damaged, onLoan) of a tool.",
+            parameters = {
+                    @Parameter(name = "id", description = "Tool ID", required = true, example = "1")
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Tool stock updated successfully"),
+            @ApiResponse(responseCode = "404", description = "Tool not found"),
+            @ApiResponse(responseCode = "400", description = "Invalid input")
+    })
+    public ResponseEntity<ToolResponse> updateStock(
+            @PathVariable Long id,
+            @Valid @RequestBody ToolStockRequest toolStockRequest) {
+
+        ToolResponse updatedTool = toolService.updateStock(id, toolStockRequest);
+        return ResponseEntity.ok(updatedTool);
+    }
+}

--- a/src/main/java/com/codeflow/toolflow/dto/category/CategoryResponse.java
+++ b/src/main/java/com/codeflow/toolflow/dto/category/CategoryResponse.java
@@ -1,0 +1,47 @@
+package com.codeflow.toolflow.dto.category;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * Data Transfer Object (DTO) representing the response data for a tool category.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CategoryResponse implements Serializable {
+
+    /**
+     * The unique identifier of the category.
+     */
+    private Long id;
+
+    /**
+     * The name of the category.
+     */
+    private String name;
+
+    /**
+     * The current status of the category (true = active, false = inactive).
+     */
+    private Boolean status;
+
+    /**
+     * The timestamp when the category was created.
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * The timestamp when the category was last updated.
+     */
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/codeflow/toolflow/dto/tool/ToolRequest.java
+++ b/src/main/java/com/codeflow/toolflow/dto/tool/ToolRequest.java
@@ -1,0 +1,107 @@
+package com.codeflow.toolflow.dto.tool;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * Data Transfer Object (DTO) representing a request for creating or updating a tool.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ToolRequest implements Serializable {
+
+    /**
+     * The name of the tool.
+     *
+     * @NotNull - This field is required.
+     * @Size(min = 2, max = 350) - The tool name must be between 2 and 350 characters.
+     */
+    @NotNull(message = "Tool name is required")
+    @Size(min = 2, max = 350, message = "Tool name must be between 2 and 350 characters")
+    private String toolName;
+
+    /**
+     * The brand or manufacturer of the tool.
+     *
+     * @NotNull - This field is required.
+     */
+    @NotNull(message = "Brand is required")
+    private String brand;
+
+    /**
+     * The number of units currently available for use.
+     * This field is optional.
+     *
+     * @Min(value = 0, message = "Available cannot be negative") - The available quantity must be non-negative.
+     */
+    @Min(value = 0, message = "Available cannot be negative")
+    private Integer available = 0;
+
+    /**
+     * The number of units currently marked as damaged or broken.
+     * This field is optional.
+     *
+     * @Min(value = 0, message = "Damaged cannot be negative") - The damaged quantity must be non-negative.
+     */
+    @Min(value = 0, message = "Damaged cannot be negative")
+    private Integer damaged = 0;
+
+    /**
+     * The number of units currently on loan (borrowed).
+     * This field is optional.
+     *
+     * @Min(value = 0, message = "On loan cannot be negative") - The on-loan quantity must be non-negative.
+     */
+    @Min(value = 0, message = "On loan cannot be negative")
+    private Integer onLoan = 0;
+
+    /**
+     * Additional notes or observations about the tool.
+     * For example: includes case, safety manual, accessories, etc.
+     * This field is optional.
+     */
+    private String notes;
+
+    /**
+     * Indicates whether the tool is consumable (e.g., gloves, screws).
+     * If true, the tool does not need to be returned or tracked individually.
+     */
+    private Boolean consumable;
+
+    /**
+     * The minimal quantity required in stock before a notification or alert should be triggered.
+     * This field is optional.
+     */
+    private Integer minimalRegistration;
+
+    /**
+     * The current status of the tool (true = active, false = deactivated).
+     *
+     * @NotNull - This field is required.
+     */
+    private Boolean status;
+
+    /**
+     * The name of the category to which this tool belongs.
+     * If the category does not exist, it will be created automatically.
+     *
+     * @NotNull - This field is required.
+     */
+    @NotNull(message = "Category is required")
+    private String category;
+}

--- a/src/main/java/com/codeflow/toolflow/dto/tool/ToolResponse.java
+++ b/src/main/java/com/codeflow/toolflow/dto/tool/ToolResponse.java
@@ -1,0 +1,91 @@
+package com.codeflow.toolflow.dto.tool;
+
+import com.codeflow.toolflow.dto.category.CategoryResponse;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * Data Transfer Object (DTO) representing the response data for a tool.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ToolResponse implements Serializable {
+
+    /**
+     * The unique identifier of the tool.
+     */
+    private Long id;
+
+    /**
+     * The name of the tool.
+     */
+    private String toolName;
+
+    /**
+     * The brand or manufacturer of the tool.
+     */
+    private String brand;
+
+    /**
+     * The total number of units available in inventory.
+     */
+    private Integer quantity;
+
+    /**
+     * The number of units currently available for use.
+     */
+    private Integer available;
+
+    /**
+     * The number of units currently marked as damaged.
+     */
+    private Integer damaged;
+
+    /**
+     * The number of units currently on loan.
+     */
+    private Integer onLoan;
+
+    /**
+     * Indicates whether the tool is consumable (i.e., not returned after use).
+     */
+    private Boolean consumable;
+
+    /**
+     * The minimum quantity required in stock before triggering an alert.
+     */
+    private Integer minimalRegistration;
+
+    /**
+     * The current status of the tool (true = active, false = inactive).
+     */
+    private Boolean status;
+
+    /**
+     * The timestamp when the tool was created.
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * The timestamp when the tool was last updated.
+     */
+    private LocalDateTime updatedAt;
+
+    /**
+     * The category to which this tool belongs.
+     */
+    private CategoryResponse category;
+}

--- a/src/main/java/com/codeflow/toolflow/dto/tool/ToolStockRequest.java
+++ b/src/main/java/com/codeflow/toolflow/dto/tool/ToolStockRequest.java
@@ -1,0 +1,40 @@
+package com.codeflow.toolflow.dto.tool;
+
+import jakarta.validation.constraints.Min;
+import lombok.Data;
+
+/**
+ * Data Transfer Object (DTO) used for optionally updating stock-related fields of a tool.
+ * <p>
+ * All fields in this DTO are optional; only non-null values will be updated.
+ */
+@Data
+public class ToolStockRequest {
+
+    /**
+     * The number of units currently available for use.
+     * This field is optional.
+     *
+     * @Min(value = 0) - Must be zero or positive if provided.
+     */
+    @Min(value = 0, message = "Available cannot be negative")
+    private Integer available = 0;
+
+    /**
+     * The number of units currently marked as damaged or broken.
+     * This field is optional.
+     *
+     * @Min(value = 0) - Must be zero or positive if provided.
+     */
+    @Min(value = 0, message = "Damaged cannot be negative")
+    private Integer damaged = 0;
+
+    /**
+     * The number of units currently on loan (borrowed).
+     * This field is optional.
+     *
+     * @Min(value = 0) - Must be zero or positive if provided.
+     */
+    @Min(value = 0, message = "On loan cannot be negative")
+    private Integer onLoan = 0;
+}

--- a/src/main/java/com/codeflow/toolflow/mapper/category/CategoryMapper.java
+++ b/src/main/java/com/codeflow/toolflow/mapper/category/CategoryMapper.java
@@ -1,0 +1,20 @@
+package com.codeflow.toolflow.mapper.category;
+
+import com.codeflow.toolflow.dto.category.CategoryResponse;
+import com.codeflow.toolflow.persistence.category.entity.Category;
+import org.mapstruct.Mapper;
+
+/**
+ * Mapper for converting between {@link Category} entities and {@link CategoryResponse} DTOs.
+ */
+@Mapper(componentModel = "spring")
+public interface CategoryMapper {
+
+    /**
+     * Converts a Category entity into a CategoryResponse DTO.
+     *
+     * @param category the category entity to convert
+     * @return the resulting CategoryResponse
+     */
+    CategoryResponse toResponse(Category category);
+}

--- a/src/main/java/com/codeflow/toolflow/mapper/tool/ToolMapper.java
+++ b/src/main/java/com/codeflow/toolflow/mapper/tool/ToolMapper.java
@@ -1,0 +1,21 @@
+package com.codeflow.toolflow.mapper.tool;
+
+import com.codeflow.toolflow.dto.tool.ToolRequest;
+import com.codeflow.toolflow.dto.tool.ToolResponse;
+import com.codeflow.toolflow.persistence.tool.entity.Tool;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ToolMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "createdBy", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "updatedBy", ignore = true)
+    @Mapping(target = "category", ignore = true)
+    Tool toEntity(ToolRequest dto);
+
+    ToolResponse toResponse(Tool entity);
+}

--- a/src/main/java/com/codeflow/toolflow/persistence/category/entity/Category.java
+++ b/src/main/java/com/codeflow/toolflow/persistence/category/entity/Category.java
@@ -1,0 +1,92 @@
+package com.codeflow.toolflow.persistence.category.entity;
+
+import com.codeflow.toolflow.persistence.tool.entity.Tool;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static jakarta.persistence.GenerationType.SEQUENCE;
+
+/**
+ * Represents a category of tools in the system.
+ * A category groups tools with common characteristics, such as function or type.
+ */
+@Entity
+@Table(name = "tool_category")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Category {
+
+    /**
+     * The sequence name used for the `id` field in the `Category` entity.
+     * Defines the database sequence `tool_category_id_seq` used for generating unique identifiers.
+     */
+    public static final String ID_SEQ = "tool_category_id_seq";
+
+    /**
+     * Represents the unique identifier for a category.
+     * Automatically generated using a database sequence.
+     */
+    @Id
+    @GeneratedValue(generator = ID_SEQ, strategy = SEQUENCE)
+    @SequenceGenerator(name = ID_SEQ, sequenceName = ID_SEQ, allocationSize = 1)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    /**
+     * The name of the tool category.
+     * For example: "Hand Tools", "Electrical Tools", "Safety Equipment".
+     */
+    @NotNull
+    private String name;
+
+    /**
+     * Indicates the current status of the category.
+     * If true, the category is active and can be assigned to tools.
+     */
+    @NotNull
+    private Boolean status;
+
+    /**
+     * The timestamp when the category was created.
+     */
+    @NotNull
+    private LocalDateTime createdAt;
+
+    /**
+     * The ID of the user who created this category.
+     */
+    @NotNull
+    private Long createdBy;
+
+    /**
+     * The timestamp of the last update made to the category.
+     */
+    @NotNull
+    private LocalDateTime updatedAt;
+
+    /**
+     * The ID of the user who last updated this category.
+     */
+    @NotNull
+    private Long updatedBy;
+
+    /**
+     * Represents the collection of tools that belong to this category.
+     * Defined as a one-to-many relationship where one category can contain multiple tools.
+     * Cascade operations and orphan removal ensure consistency when tools are managed via the category.
+     */
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Tool> tools = new ArrayList<>();
+}

--- a/src/main/java/com/codeflow/toolflow/persistence/category/repository/CategoryRepository.java
+++ b/src/main/java/com/codeflow/toolflow/persistence/category/repository/CategoryRepository.java
@@ -1,0 +1,31 @@
+package com.codeflow.toolflow.persistence.category.repository;
+
+import com.codeflow.toolflow.persistence.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * Repository interface for managing {@link Category} entities in the database.
+ * <p>
+ * This interface provides standard JPA-based operations such as saving, deleting,
+ * and finding categories. It also includes custom query methods for specific business needs.
+ * <p>
+ * It extends {@link JpaRepository} to gain access to built-in JPA functionality,
+ * such as pagination and sorting.
+ */
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    /**
+     * Finds a category by its name, ignoring case sensitivity.
+     * <p>
+     * This method is useful when matching category names regardless of how the text is capitalized.
+     * For example, searching "Electrical Tools" will match "electrical tools", "ELECTRICAL TOOLS", etc.
+     *
+     * @param name the name of the category to search for; must not be null
+     * @return an {@link Optional} containing the matching {@link Category} if found, or empty otherwise
+     */
+    Optional<Category> findByNameIgnoreCase(String name);
+}

--- a/src/main/java/com/codeflow/toolflow/persistence/tool/entity/Tool.java
+++ b/src/main/java/com/codeflow/toolflow/persistence/tool/entity/Tool.java
@@ -1,0 +1,141 @@
+package com.codeflow.toolflow.persistence.tool.entity;
+
+import com.codeflow.toolflow.persistence.category.entity.Category;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static jakarta.persistence.GenerationType.SEQUENCE;
+
+/**
+ * Represents a tool in the inventory system.
+ * Each tool contains information about its quantity, status, usage, and category association.
+ */
+@Entity
+@Table(name = "tool")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Tool {
+
+    /**
+     * The sequence name used for the `id` field in the `Tool` entity.
+     * This constant  defines the database sequence `tool_id_seq` used to generate unique tool identifiers.
+     */
+    public static final String ID_SEQ = "tool_id_seq";
+
+    /**
+     * Represents the unique identifier for the tool.
+     * It is automatically generated using a database sequence strategy.
+     */
+    @Id
+    @GeneratedValue(generator = ID_SEQ, strategy = SEQUENCE)
+    @SequenceGenerator(name = ID_SEQ, sequenceName = ID_SEQ, allocationSize = 1)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    /**
+     * The name or description of the tool.
+     * For example: "Cordless Drill", "Welding Helmet", etc.
+     * Maximum allowed length is 350 characters.
+     */
+    @NotNull
+    @Column(length = 350)
+    private String toolName;
+
+    /**
+     * The total quantity of this tool available in inventory.
+     */
+    @NotNull
+    @Column(columnDefinition ="integer default 0")
+    private Integer quantity = 0;
+
+    /**
+     * The brand or manufacturer of the tool.
+     */
+    @NotNull
+    private String brand;
+
+    /**
+     * The number of units currently available for use.
+     * This value is updated as tools are loaned or returned.
+     */
+    @Column(columnDefinition ="integer default 0")
+    private Integer available = 0;
+
+    /**
+     * The number of tools marked as damaged or not usable.
+     */
+    @Column(columnDefinition ="integer default 0")
+    private Integer damaged = 0;
+
+    /**
+     * The number of units currently loaned out to users.
+     */
+    @Column(columnDefinition ="integer default 0")
+    private Integer onLoan = 0;
+
+    /**
+     * Optional notes about the tool.
+     * For example: condition, accessories included, warnings, etc.
+     */
+    private String notes;
+
+    /**
+     * Indicates whether the tool is consumable.
+     * Consumables are items that do not need to be returned, such as gloves or screws.
+     */
+    private Boolean consumable;
+
+    /**
+     * The minimum required quantity before triggering an alert or replenishment request.
+     */
+    private Integer minimalRegistration;
+
+    /**
+     * Indicates whether the tool is active in the system.
+     * If false, the tool is considered deactivated or no longer in circulation.
+     */
+    @NotNull
+    private Boolean status;
+
+    /**
+     * Timestamp of when the tool record was created.
+     */
+    @NotNull
+    private LocalDateTime createdAt;
+
+    /**
+     * The ID of the user who created this tool record.
+     */
+    @NotNull
+    private Long createdBy;
+
+    /**
+     * Timestamp of the last update to this tool record.
+     */
+    @NotNull
+    private LocalDateTime updatedAt;
+
+    /**
+     * The ID of the user who last updated this tool record.
+     */
+    @NotNull
+    private Long updatedBy;
+
+    /**
+     * The category to which this tool belongs.
+     * This is a many-to-one relationship, as many tools can belong to a single category.
+     */
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "category", referencedColumnName = "id")
+    private Category category;
+}

--- a/src/main/java/com/codeflow/toolflow/persistence/tool/repository/ToolRepository.java
+++ b/src/main/java/com/codeflow/toolflow/persistence/tool/repository/ToolRepository.java
@@ -1,0 +1,21 @@
+package com.codeflow.toolflow.persistence.tool.repository;
+
+import com.codeflow.toolflow.persistence.tool.entity.Tool;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository interface for managing {@link Tool} entities in the database.
+ * <p>
+ * This interface provides standard JPA-based operations such as saving, deleting,
+ * and finding tools. It also includes support for dynamic queries using specifications,
+ * allowing more flexible and complex filtering.
+ * <p>
+ * It extends {@link JpaRepository} to gain access to built-in JPA functionality,
+ * such as pagination and sorting, and {@link JpaSpecificationExecutor} to support
+ * custom queries based on specifications.
+ */
+@Repository
+public interface ToolRepository extends JpaRepository<Tool, Long>, JpaSpecificationExecutor<Tool> {
+}

--- a/src/main/java/com/codeflow/toolflow/persistence/tool/repository/ToolSpecifications.java
+++ b/src/main/java/com/codeflow/toolflow/persistence/tool/repository/ToolSpecifications.java
@@ -1,0 +1,54 @@
+package com.codeflow.toolflow.persistence.tool.repository;
+
+import com.codeflow.toolflow.persistence.tool.entity.Tool;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+
+/**
+ * Utility class containing specifications for the {@link Tool} entity
+ * to support dynamic filtering and searching in the database.
+ */
+public class ToolSpecifications {
+
+    /**
+     * Filters tools with status=true (active).
+     *
+     * @return a {@link Specification} filtering only active tools
+     */
+    public static Specification<Tool> toolIsActive() {
+        return (root, query, cb) -> cb.equal(root.get("status"), true);
+    }
+
+    /**
+     * Performs a search for multiple values on a specific column of the {@link Tool} entity.
+     * <p>
+     * If the column is nested (e.g., "category.name"), it will create a join to the related entity.
+     * For text-based columns such as "toolName" or "brand", it performs a case-insensitive partial match.
+     * For other types, it performs an exact match using the SQL IN clause.
+     *
+     * @param column the column name to filter by (supports nested properties with dot notation)
+     * @param values the list of values to search for
+     * @return a {@link Specification} representing the filtering condition
+     */
+    public static Specification<Tool> searchByColumnValues(String column, List<String> values) {
+        return (root, query, cb) -> {
+            if (column.contains(".")) {
+                String[] parts = column.split("\\.");
+                Join<Object, Object> join = root.join(parts[0]);
+                return join.get(parts[1]).in(values);
+            } else {
+                if (List.of("toolName", "brand").contains(column)) {
+                    List<Predicate> predicates = values.stream()
+                            .map(value -> cb.like(cb.lower(root.get(column)), "%" + value.toLowerCase() + "%"))
+                            .toList();
+                    return cb.or(predicates.toArray(new Predicate[0]));
+                } else {
+                    return root.get(column).in(values);
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/com/codeflow/toolflow/service/category/CategoryService.java
+++ b/src/main/java/com/codeflow/toolflow/service/category/CategoryService.java
@@ -1,0 +1,27 @@
+package com.codeflow.toolflow.service.category;
+
+import com.codeflow.toolflow.dto.category.CategoryResponse;
+import com.codeflow.toolflow.persistence.category.entity.Category;
+
+import java.util.List;
+
+/**
+ * Service interface for handling category-related operations.
+ */
+public interface CategoryService {
+
+    /**
+     * Finds a category by its name or creates a new one if it doesn't exist.
+     *
+     * @param name the name of the category to look for or create
+     * @return a {@link Category} entity, either existing or newly created
+     */
+    Category findOrCreateByName(String name);
+
+    /**
+     * Retrieves all existing categories in the system.
+     *
+     * @return a list of {@link CategoryResponse} objects representing each category
+     */
+    List<CategoryResponse> getAll();
+}

--- a/src/main/java/com/codeflow/toolflow/service/category/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/codeflow/toolflow/service/category/impl/CategoryServiceImpl.java
@@ -1,0 +1,83 @@
+package com.codeflow.toolflow.service.category.impl;
+
+import com.codeflow.toolflow.dto.auth.UserLogin;
+import com.codeflow.toolflow.dto.category.CategoryResponse;
+import com.codeflow.toolflow.mapper.category.CategoryMapper;
+import com.codeflow.toolflow.persistence.category.entity.Category;
+import com.codeflow.toolflow.persistence.category.repository.CategoryRepository;
+import com.codeflow.toolflow.service.category.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Service implementation for category-related operations.
+ * <p>
+ * This service is responsible for resolving existing categories by name (case-insensitive),
+ * or creating new ones if they don't exist, including setting audit metadata automatically.
+ */
+@Service
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final CategoryMapper categoryMapper;
+
+    /**
+     * Finds an existing category by name, ignoring case. If no category is found,
+     * creates a new one with the current authenticated user as the creator and updater.
+     *
+     * @param name the name of the category to find or create
+     * @return the resolved or newly created {@link Category}
+     */
+    @Override
+    public Category findOrCreateByName(String name) {
+        return categoryRepository.findByNameIgnoreCase(name)
+                .orElseGet(() -> {
+                    Long userId = getCurrentUserId();
+                    Category newCategory = Category.builder()
+                            .name(name)
+                            .status(true)
+                            .createdAt(LocalDateTime.now())
+                            .updatedAt(LocalDateTime.now())
+                            .createdBy(userId)
+                            .updatedBy(userId)
+                            .build();
+                    return categoryRepository.save(newCategory);
+                });
+    }
+
+    /**
+     * Retrieves all categories currently stored in the system.
+     * <p>
+     * Each category is mapped to a {@link CategoryResponse} DTO to decouple
+     * the internal entity representation from the API response.
+     *
+     * @return a list of {@link CategoryResponse} objects representing all categories
+     */
+    @Override
+    public List<CategoryResponse> getAll() {
+        return categoryRepository.findAll()
+                .stream()
+                .map(categoryMapper::toResponse)
+                .toList();
+    }
+
+    /**
+     * Retrieves the ID of the current authenticated user from the security context.
+     *
+     * @return the user ID of the authenticated user
+     * @throws IllegalStateException if no authenticated user is present in the security context
+     */
+    private Long getCurrentUserId() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.getPrincipal() instanceof UserLogin userDetails) {
+            return userDetails.getId();
+        }
+        throw new IllegalStateException("No authenticated user found.");
+    }
+}
+

--- a/src/main/java/com/codeflow/toolflow/service/tool/ToolService.java
+++ b/src/main/java/com/codeflow/toolflow/service/tool/ToolService.java
@@ -1,0 +1,58 @@
+package com.codeflow.toolflow.service.tool;
+
+import com.codeflow.toolflow.dto.tool.ToolRequest;
+import com.codeflow.toolflow.dto.tool.ToolResponse;
+import com.codeflow.toolflow.dto.tool.ToolStockRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+/**
+ * Interface defining tool-related services.
+ */
+public interface ToolService {
+
+    /**
+     * Registers a new tool in the system.
+     *
+     * @param toolRequest DTO with tool data.
+     * @return the created ToolResponse.
+     */
+    ToolResponse registerOneTool(ToolRequest toolRequest);
+
+    /**
+     * Updates an existing tool.
+     *
+     * @param id          the ID of the tool.
+     * @param toolRequest updated data.
+     * @return updated ToolResponse.
+     */
+    ToolResponse updateOneTool(Long id, ToolRequest toolRequest);
+
+    /**
+     * Retrieves a single tool by ID.
+     *
+     * @param id the tool's ID.
+     * @return ToolResponse.
+     */
+    ToolResponse getOne(Long id);
+
+    /**
+     * Deletes (soft delete) a tool.
+     *
+     * @param id ID of the tool to delete.
+     */
+    void deleteOneTool(Long id);
+
+    /**
+     * Returns a paginated list of tools.
+     *
+     * @param pageable pagination and sorting configuration
+     * @param filters  list of filter expressions in the format {@code column:value1,value2,...}
+     * @return a {@link Page} of {@link ToolResponse} objects matching the criteria
+     */
+    Page<ToolResponse> getPage(Pageable pageable, List<String> filters);
+
+    ToolResponse updateStock(Long id, ToolStockRequest toolStockRequest);
+}

--- a/src/main/java/com/codeflow/toolflow/service/tool/impl/ToolServiceImpl.java
+++ b/src/main/java/com/codeflow/toolflow/service/tool/impl/ToolServiceImpl.java
@@ -1,0 +1,215 @@
+package com.codeflow.toolflow.service.tool.impl;
+
+import com.codeflow.toolflow.dto.auth.UserLogin;
+import com.codeflow.toolflow.dto.tool.ToolRequest;
+import com.codeflow.toolflow.dto.tool.ToolResponse;
+import com.codeflow.toolflow.dto.tool.ToolStockRequest;
+import com.codeflow.toolflow.mapper.tool.ToolMapper;
+import com.codeflow.toolflow.persistence.tool.entity.Tool;
+import com.codeflow.toolflow.persistence.tool.repository.ToolRepository;
+import com.codeflow.toolflow.persistence.tool.repository.ToolSpecifications;
+import com.codeflow.toolflow.service.category.CategoryService;
+import com.codeflow.toolflow.service.tool.ToolService;
+import com.codeflow.toolflow.util.exception.ToolNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Service implementation for tool-related operations.
+ * <p>
+ * This service handles the core business logic for creating, updating, retrieving,
+ * deleting, and listing tools, as well as category resolution and audit information tracking.
+ */
+@Service
+@RequiredArgsConstructor
+public class ToolServiceImpl implements ToolService {
+
+    private final ToolRepository toolRepository;
+    private final CategoryService categoryService;
+    private final ToolMapper toolMapper;
+
+    /**
+     * Registers a new tool in the system based on the data received in the {@link ToolRequest}.
+     * Automatically creates a category if it does not exist, and tracks audit information
+     * for the creator.
+     *
+     * @param request the request object containing tool data to be saved
+     * @return the created {@link ToolResponse}
+     */
+    @Override
+    public ToolResponse registerOneTool(ToolRequest request) {
+        Tool tool = mapRequestToEntity(request, new Tool());
+        tool.setStatus(true);
+        tool.setQuantity(Optional.ofNullable(tool.getAvailable()).orElse(0));
+        tool.setDamaged(0);
+        tool.setOnLoan(0);
+        Tool saved = toolRepository.save(tool);
+        return toolMapper.toResponse(saved);
+    }
+
+    /**
+     * Updates the details of an existing tool identified by its ID.
+     * The method retrieves the existing record, applies updates from the {@link ToolRequest},
+     * and tracks audit metadata such as last updater and timestamp.
+     *
+     * @param id      the ID of the tool to be updated
+     * @param request the object containing the updated tool data
+     * @return the updated {@link ToolResponse}
+     */
+    @Override
+    public ToolResponse updateOneTool(Long id, ToolRequest request) {
+        Tool existing = findOneById(id);
+        Tool updated = mapRequestToEntity(request, existing);
+        int totalQuantity = updated.getAvailable() + updated.getDamaged() + updated.getOnLoan();
+        updated.setQuantity(totalQuantity);
+        Tool saved = toolRepository.save(updated);
+        return toolMapper.toResponse(saved);
+    }
+
+    /**
+     * Retrieves a tool by its ID and returns its full details.
+     *
+     * @param id the unique identifier of the tool
+     * @return the {@link ToolResponse} containing tool details
+     * @throws ToolNotFoundException if the tool is not found
+     */
+    @Override
+    public ToolResponse getOne(Long id) {
+        return toolMapper.toResponse(findOneById(id));
+    }
+
+    /**
+     * Performs a soft delete on a tool by setting its status to false.
+     * This method does not remove the tool from the database.
+     *
+     * @param id the ID of the tool to deactivate
+     */
+    @Override
+    public void deleteOneTool(Long id) {
+        Tool tool = findOneById(id);
+        tool.setStatus(false);
+        tool.setAvailable(0);
+        tool.setDamaged(0);
+        tool.setOnLoan(0);
+        tool.setUpdatedAt(LocalDateTime.now());
+        tool.setUpdatedBy(getCurrentUserId());
+        toolRepository.save(tool);
+    }
+
+    /**
+     * Retrieves a paginated list of active tools, optionally filtered by a search query
+     * and search column. The results are dynamically built using specifications.
+     *
+     * @param pageable the pagination and sorting information
+     * @param filters  a list of search filters in the format {@code column:value1,value2,...}
+     * @return a {@link Page} of {@link ToolResponse} objects matching the filters
+     */
+    @Override
+    public Page<ToolResponse> getPage(Pageable pageable, List<String> filters) {
+        Specification<Tool> spec = Specification.where(ToolSpecifications.toolIsActive());
+
+        if (filters != null && !filters.isEmpty()) {
+            for (String filter : filters) {
+                String[] parts = filter.split(":");
+                if (parts.length >= 2) {
+                    String column = parts[0].trim();
+                    String[] values = parts[1].split(",");
+                    spec = spec.and(ToolSpecifications.searchByColumnValues(column, Arrays.asList(values)));
+                }
+            }
+        }
+
+        Page<Tool> tools = toolRepository.findAll(spec, pageable);
+        return tools.map(toolMapper::toResponse);
+    }
+
+    @Override
+    public ToolResponse updateStock(Long id, ToolStockRequest request) {
+        Tool tool = toolRepository.findById(id)
+                .orElseThrow(() -> new ToolNotFoundException("Tool" + id + " not found"));
+
+        if (request.getAvailable() != null) {
+            tool.setAvailable(request.getAvailable());
+        }
+        if (request.getDamaged() != null) {
+            tool.setDamaged(request.getDamaged());
+        }
+        if (request.getOnLoan() != null) {
+            tool.setOnLoan(request.getOnLoan());
+        }
+
+        int totalQuantity = (tool.getAvailable() != null ? tool.getAvailable() : 0) +
+                (tool.getDamaged() != null ? tool.getDamaged() : 0) +
+                (tool.getOnLoan() != null ? tool.getOnLoan() : 0);
+
+        tool.setQuantity(totalQuantity);
+
+        tool.setUpdatedAt(LocalDateTime.now());
+        tool.setUpdatedBy(getCurrentUserId());
+
+        Tool updatedTool = toolRepository.save(tool);
+        return toolMapper.toResponse(updatedTool);
+    }
+
+    /**
+     * Retrieves a {@link Tool} entity by its ID.
+     *
+     * @param id the ID of the tool
+     * @return the {@link Tool} entity
+     * @throws ToolNotFoundException if the tool does not exist
+     */
+    private Tool findOneById(Long id) {
+        return toolRepository.findById(id).orElseThrow(() -> new ToolNotFoundException("Tool not found"));
+    }
+
+    /**
+     * Maps a {@link ToolRequest} DTO into a {@link Tool} entity.
+     * Performs category resolution and applies auditing metadata (createdBy, updatedBy).
+     *
+     * @param request      the request object with input data
+     * @param existingTool the existing tool (empty for new tool, filled for update)
+     * @return the mapped {@link Tool} entity ready to be persisted
+     */
+    private Tool mapRequestToEntity(ToolRequest request, Tool existingTool) {
+        Tool tool = toolMapper.toEntity(request);
+        tool.setId(existingTool.getId());
+        tool.setCategory(categoryService.findOrCreateByName(request.getCategory()));
+
+        Long userId = getCurrentUserId();
+        tool.setUpdatedAt(LocalDateTime.now());
+        tool.setUpdatedBy(userId);
+
+        if (tool.getId() == null) {
+            tool.setCreatedAt(LocalDateTime.now());
+            tool.setCreatedBy(userId);
+        } else {
+            tool.setCreatedAt(existingTool.getCreatedAt());
+            tool.setCreatedBy(existingTool.getCreatedBy());
+        }
+
+        return tool;
+    }
+
+    /**
+     * Retrieves the current authenticated user's ID from the security context.
+     *
+     * @return the user ID
+     * @throws IllegalStateException if no authenticated user is found in the context
+     */
+    Long getCurrentUserId() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.getPrincipal() instanceof UserLogin userDetails) {
+            return userDetails.getId();
+        }
+        throw new IllegalStateException("No authenticated user found.");
+    }
+}

--- a/src/main/java/com/codeflow/toolflow/util/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeflow/toolflow/util/exception/GlobalExceptionHandler.java
@@ -179,7 +179,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(ToolNotFoundException.class)
-    public ResponseEntity<?> handlerToolNotFoundException(HttpServletRequest request, UserNotFoundException exception) {
+    public ResponseEntity<?> handlerToolNotFoundException(HttpServletRequest request, ToolNotFoundException exception) {
         ApiError apiError = new ApiError();
         apiError.setBackendMessage(exception.getLocalizedMessage());
         apiError.setUrl(request.getRequestURL().toString());

--- a/src/main/java/com/codeflow/toolflow/util/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeflow/toolflow/util/exception/GlobalExceptionHandler.java
@@ -177,4 +177,16 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(apiError);
     }
+
+    @ExceptionHandler(ToolNotFoundException.class)
+    public ResponseEntity<?> handlerToolNotFoundException(HttpServletRequest request, UserNotFoundException exception) {
+        ApiError apiError = new ApiError();
+        apiError.setBackendMessage(exception.getLocalizedMessage());
+        apiError.setUrl(request.getRequestURL().toString());
+        apiError.setMethod(request.getMethod());
+        apiError.setTimestamp(LocalDateTime.now());
+        apiError.setMessage("La herramienta no existe");
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(apiError);
+    }
 }

--- a/src/main/java/com/codeflow/toolflow/util/exception/ToolNotFoundException.java
+++ b/src/main/java/com/codeflow/toolflow/util/exception/ToolNotFoundException.java
@@ -1,0 +1,16 @@
+package com.codeflow.toolflow.util.exception;
+
+/**
+ * Exception thrown when an entity is not found in the database.
+ */
+public class ToolNotFoundException extends RuntimeException {
+
+    /**
+     * Constructs a new EntityNotFoundException with a custom message.
+     *
+     * @param message the detail message explaining the exception.
+     */
+    public ToolNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/db/migration/V1.0.2__create_tool_and_category.sql
+++ b/src/main/resources/db/migration/V1.0.2__create_tool_and_category.sql
@@ -1,0 +1,41 @@
+-- -------------------------------------- category -----------------------------------------------
+
+CREATE TABLE IF NOT EXISTS tool_category
+(
+    id         BIGINT       NOT NULL,
+    name       VARCHAR(255) NOT NULL,
+    status     BOOLEAN      NOT NULL,
+    created_at TIMESTAMP    NOT NULL,
+    created_by BIGINT       NOT NULL,
+    updated_at TIMESTAMP    NOT NULL,
+    updated_by BIGINT       NOT NULL,
+    PRIMARY KEY (id)
+    );
+
+CREATE SEQUENCE IF NOT EXISTS tool_category_id_seq START WITH 1 INCREMENT BY 1;
+
+-- -------------------------------------- tool -----------------------------------------------
+
+CREATE TABLE IF NOT EXISTS tool
+(
+    id                   BIGINT       NOT NULL,
+    tool_name            VARCHAR(350) NOT NULL,
+    brand                VARCHAR(255) NOT NULL,
+    quantity             INTEGER      NOT NULL,
+    available            INTEGER,
+    damaged              INTEGER,
+    on_loan              INTEGER,
+    notes                TEXT,
+    consumable           BOOLEAN,
+    minimal_registration INTEGER,
+    status               BOOLEAN      NOT NULL,
+    created_at           TIMESTAMP    NOT NULL,
+    created_by           BIGINT       NOT NULL,
+    updated_at           TIMESTAMP    NOT NULL,
+    updated_by           BIGINT       NOT NULL,
+    category             BIGINT,
+    PRIMARY KEY (id),
+    FOREIGN KEY (category) REFERENCES tool_category (id)
+    );
+
+CREATE SEQUENCE IF NOT EXISTS tool_id_seq START WITH 1 INCREMENT BY 1;

--- a/src/test/java/com/codeflow/toolflow/service/category/impl/CategoryServiceImplTest.java
+++ b/src/test/java/com/codeflow/toolflow/service/category/impl/CategoryServiceImplTest.java
@@ -1,0 +1,146 @@
+package com.codeflow.toolflow.service.category.impl;
+
+import com.codeflow.toolflow.dto.auth.UserLogin;
+import com.codeflow.toolflow.dto.category.CategoryResponse;
+import com.codeflow.toolflow.mapper.category.CategoryMapper;
+import com.codeflow.toolflow.persistence.category.entity.Category;
+import com.codeflow.toolflow.persistence.category.repository.CategoryRepository;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CategoryServiceImplTest {
+
+    @InjectMocks
+    private CategoryServiceImpl categoryService;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private CategoryMapper categoryMapper;
+
+    private UserLogin mockUser;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        mockUser = new UserLogin();
+        mockUser.setId(1L);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(mockUser, null)
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private Category mockCategory(String name) {
+        return Category.builder()
+                .id(1L)
+                .name(name)
+                .status(true)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .createdBy(1L)
+                .updatedBy(1L)
+                .build();
+    }
+
+    @Test
+    void shouldReturnExistingCategoryByName() {
+        Category existing = mockCategory("Hardware");
+
+        when(categoryRepository.findByNameIgnoreCase("Hardware"))
+                .thenReturn(Optional.of(existing));
+
+        Category result = categoryService.findOrCreateByName("Hardware");
+
+        assertThat(result).isEqualTo(existing);
+        verify(categoryRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldCreateNewCategoryIfNotFound() {
+        when(categoryRepository.findByNameIgnoreCase("Software")).thenReturn(Optional.empty());
+
+        Category saved = mockCategory("Software");
+
+        when(categoryRepository.save(any())).thenReturn(saved);
+
+        Category result = categoryService.findOrCreateByName("Software");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("Software");
+        assertThat(result.getCreatedBy()).isEqualTo(1L);
+        verify(categoryRepository).save(any(Category.class));
+    }
+
+    @Test
+    void shouldReturnAllCategoriesMapped() {
+        List<Category> entities = List.of(
+                mockCategory("Hardware"),
+                mockCategory("Software")
+        );
+        List<CategoryResponse> responses = List.of(
+                CategoryResponse.builder()
+                        .id(1L)
+                        .name("Hardware")
+                        .status(true)
+                        .createdAt(LocalDateTime.now())
+                        .updatedAt(LocalDateTime.now())
+                        .build(),
+                CategoryResponse.builder()
+                        .id(2L)
+                        .name("Software")
+                        .status(true)
+                        .createdAt(LocalDateTime.now())
+                        .updatedAt(LocalDateTime.now())
+                        .build()
+        );
+
+        when(categoryRepository.findAll()).thenReturn(entities);
+        when(categoryMapper.toResponse(entities.get(0))).thenReturn(responses.get(0));
+        when(categoryMapper.toResponse(entities.get(1))).thenReturn(responses.get(1));
+
+        List<CategoryResponse> result = categoryService.getAll();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getName()).isEqualTo("Hardware");
+        assertThat(result.get(1).getName()).isEqualTo("Software");
+    }
+
+    @Test
+    void shouldThrowIfNoAuthenticatedUser() {
+        SecurityContextHolder.clearContext(); // No auth context
+
+        CategoryServiceImpl service = new CategoryServiceImpl(categoryRepository, categoryMapper);
+
+        assertThatThrownBy(() -> {
+            service.findOrCreateByName("Test");
+        }).isInstanceOf(IllegalStateException.class)
+                .hasMessage("No authenticated user found.");
+    }
+
+    @Test
+    void shouldThrowIfPrincipalIsNotUserLogin() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("anonymous", null)
+        );
+
+        CategoryServiceImpl service = new CategoryServiceImpl(categoryRepository, categoryMapper);
+
+        assertThatThrownBy(() -> service.findOrCreateByName("Any"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("No authenticated user found.");
+    }
+}

--- a/src/test/java/com/codeflow/toolflow/service/tool/impl/ToolServiceImplTest.java
+++ b/src/test/java/com/codeflow/toolflow/service/tool/impl/ToolServiceImplTest.java
@@ -1,0 +1,344 @@
+package com.codeflow.toolflow.service.tool.impl;
+
+import com.codeflow.toolflow.dto.auth.UserLogin;
+import com.codeflow.toolflow.dto.tool.ToolRequest;
+import com.codeflow.toolflow.dto.tool.ToolResponse;
+import com.codeflow.toolflow.dto.tool.ToolStockRequest;
+import com.codeflow.toolflow.mapper.tool.ToolMapper;
+import com.codeflow.toolflow.persistence.category.entity.Category;
+import com.codeflow.toolflow.persistence.tool.entity.Tool;
+import com.codeflow.toolflow.persistence.tool.repository.ToolRepository;
+import com.codeflow.toolflow.service.category.CategoryService;
+import com.codeflow.toolflow.util.exception.ToolNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class ToolServiceImplTest {
+
+    @InjectMocks
+    private ToolServiceImpl toolService;
+
+    @Mock
+    private ToolRepository toolRepository;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @Mock
+    private ToolMapper toolMapper;
+
+    @Captor
+    private ArgumentCaptor<Tool> toolCaptor;
+
+    private UserLogin mockUser;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        mockUser = new UserLogin();
+        mockUser.setId(1L);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(mockUser, null)
+        );
+    }
+
+    private Tool createMockTool() {
+        Tool tool = new Tool();
+        tool.setId(1L);
+        tool.setAvailable(5);
+        tool.setOnLoan(3);
+        tool.setDamaged(2);
+        tool.setQuantity(10);
+        tool.setStatus(true);
+        tool.setCreatedAt(LocalDateTime.now().minusDays(1));
+        tool.setUpdatedAt(LocalDateTime.now());
+        tool.setCreatedBy(1L);
+        tool.setUpdatedBy(1L);
+        return tool;
+    }
+
+    private Category createMockCategory() {
+        Category category = new Category();
+        category.setId(99L);
+        category.setName("Mock Category");
+        return category;
+    }
+
+    @Test
+    void shouldRegisterTool() {
+        ToolRequest request = new ToolRequest();
+        Tool tool = createMockTool();
+        Category category = createMockCategory();
+
+        ToolResponse responseMock = new ToolResponse();
+        responseMock.setToolName(tool.getToolName());
+
+        when(toolMapper.toEntity(request)).thenReturn(tool);
+        when(categoryService.findOrCreateByName(any())).thenReturn(category);
+        when(toolRepository.save(any())).thenReturn(tool);
+        when(toolMapper.toResponse(tool)).thenReturn(responseMock);
+
+        ToolResponse response = toolService.registerOneTool(request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getToolName()).isEqualTo(tool.getToolName());
+
+        verify(toolRepository).save(toolCaptor.capture());
+        Tool captured = toolCaptor.getValue();
+
+        assertThat(captured.getCreatedBy()).isEqualTo(1L);
+        assertThat(captured.getStatus()).isTrue();
+        assertThat(captured.getQuantity()).isEqualTo(captured.getAvailable());
+    }
+
+    @Test
+    void shouldUpdateTool() {
+        ToolRequest request = new ToolRequest();
+        Tool existing = createMockTool();
+        Tool updated = createMockTool();
+        updated.setAvailable(10);
+        updated.setOnLoan(5);
+        updated.setDamaged(2);
+        updated.setQuantity(17);
+
+        Category category = createMockCategory();
+
+        when(toolRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(toolMapper.toEntity(request)).thenReturn(updated);
+        when(categoryService.findOrCreateByName(any())).thenReturn(category);
+        when(toolRepository.save(any())).thenReturn(updated);
+        when(toolMapper.toResponse(any())).thenReturn(new ToolResponse());
+
+        ToolResponse response = toolService.updateOneTool(1L, request);
+
+        assertThat(response).isNotNull();
+        verify(toolRepository).save(toolCaptor.capture());
+        Tool captured = toolCaptor.getValue();
+        assertThat(captured.getQuantity()).isEqualTo(17);
+    }
+
+    @Test
+    void shouldGetToolById() {
+        Tool tool = createMockTool();
+        when(toolRepository.findById(1L)).thenReturn(Optional.of(tool));
+        when(toolMapper.toResponse(tool)).thenReturn(new ToolResponse());
+
+        ToolResponse response = toolService.getOne(1L);
+
+        assertThat(response).isNotNull();
+    }
+
+    @Test
+    void shouldThrowWhenToolNotFound() {
+        when(toolRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> toolService.getOne(1L))
+                .isInstanceOf(ToolNotFoundException.class)
+                .hasMessage("Tool not found");
+    }
+
+    @Test
+    void shouldDeleteToolSoftly() {
+        Tool tool = createMockTool();
+        when(toolRepository.findById(1L)).thenReturn(Optional.of(tool));
+
+        toolService.deleteOneTool(1L);
+
+        verify(toolRepository).save(toolCaptor.capture());
+        Tool captured = toolCaptor.getValue();
+        assertThat(captured.getStatus()).isFalse();
+        assertThat(captured.getAvailable()).isZero();
+        assertThat(captured.getUpdatedBy()).isEqualTo(1L);
+    }
+
+    @Test
+    void shouldReturnPageWhenFiltersAreNull() {
+        Pageable pageable = PageRequest.of(0, 5);
+        Page<Tool> page = new PageImpl<>(List.of(createMockTool()));
+        when(toolRepository.findAll(any(Specification.class), eq(pageable)))
+                .thenReturn(page);
+        when(toolMapper.toResponse(any())).thenReturn(new ToolResponse());
+
+        Page<ToolResponse> result = toolService.getPage(pageable, null);
+
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    void shouldReturnPageWhenFiltersAreEmpty() {
+        Pageable pageable = PageRequest.of(0, 5);
+        Page<Tool> page = new PageImpl<>(List.of(createMockTool()));
+        when(toolRepository.findAll(any(Specification.class), eq(pageable)))
+                .thenReturn(page);
+        when(toolMapper.toResponse(any())).thenReturn(new ToolResponse());
+
+        Page<ToolResponse> result = toolService.getPage(pageable, Collections.emptyList());
+
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    void shouldIgnoreInvalidFilterWithoutColon() {
+        Pageable pageable = PageRequest.of(0, 5);
+        List<String> filters = List.of("invalidfilter");
+        Page<Tool> page = new PageImpl<>(List.of(createMockTool()));
+
+        when(toolRepository.findAll(any(Specification.class), eq(pageable)))
+                .thenReturn(page);
+        when(toolMapper.toResponse(any())).thenReturn(new ToolResponse());
+
+        Page<ToolResponse> result = toolService.getPage(pageable, filters);
+
+        assertThat(result).isNotEmpty(); // still runs, just skips that invalid filter
+    }
+
+    @Test
+    void shouldReturnEmptyPageIfNoToolsFound() {
+        Pageable pageable = PageRequest.of(0, 5);
+        List<String> filters = List.of("status:true");
+        Page<Tool> emptyPage = new PageImpl<>(Collections.emptyList());
+
+        when(toolRepository.findAll(any(Specification.class), eq(pageable)))
+                .thenReturn(emptyPage);
+
+        Page<ToolResponse> result = toolService.getPage(pageable, filters);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldGetPageWithFilters() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Tool tool = createMockTool();
+        Page<Tool> page = new PageImpl<>(List.of(tool));
+
+        when(toolRepository.findAll(any(Specification.class), eq(pageable)))
+                .thenReturn(page);
+        when(toolMapper.toResponse(tool)).thenReturn(new ToolResponse());
+
+        Page<ToolResponse> result = toolService.getPage(pageable, List.of("status:true"));
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void shouldThrowWhenUpdatingStockAndToolNotFound() {
+        when(toolRepository.findById(1L)).thenReturn(Optional.empty());
+
+        ToolStockRequest request = new ToolStockRequest();
+
+        assertThatThrownBy(() -> toolService.updateStock(1L, request))
+                .isInstanceOf(ToolNotFoundException.class)
+                .hasMessage("Tool1 not found");
+    }
+
+    @Test
+    void shouldUpdateStockWhenAllFieldsAreNull() {
+        Tool tool = new Tool();
+        tool.setAvailable(null);
+        tool.setDamaged(null);
+        tool.setOnLoan(null);
+
+        ToolStockRequest request = new ToolStockRequest(); // todos los campos null
+
+        when(toolRepository.findById(1L)).thenReturn(Optional.of(tool));
+        when(toolRepository.save(any())).thenReturn(tool);
+        when(toolMapper.toResponse(tool)).thenReturn(new ToolResponse());
+
+        ToolResponse response = toolService.updateStock(1L, request);
+
+        assertThat(response).isNotNull();
+        verify(toolRepository).save(toolCaptor.capture());
+        assertThat(toolCaptor.getValue().getQuantity()).isEqualTo(0); // total 0
+    }
+
+    @Test
+    void shouldUpdateOnlyAvailableIfOthersAreNull() {
+        Tool tool = new Tool();
+        tool.setAvailable(0);
+        tool.setDamaged(null);
+        tool.setOnLoan(null);
+
+        ToolStockRequest request = new ToolStockRequest();
+        request.setAvailable(8); // solo este no es null
+
+        when(toolRepository.findById(1L)).thenReturn(Optional.of(tool));
+        when(toolRepository.save(any())).thenReturn(tool);
+        when(toolMapper.toResponse(tool)).thenReturn(new ToolResponse());
+
+        ToolResponse response = toolService.updateStock(1L, request);
+
+        assertThat(response).isNotNull();
+        verify(toolRepository).save(toolCaptor.capture());
+        Tool saved = toolCaptor.getValue();
+        assertThat(saved.getAvailable()).isEqualTo(8);
+        assertThat(saved.getDamaged()).isNull(); // no lo tocamos
+        assertThat(saved.getQuantity()).isEqualTo(8); // solo available suma
+    }
+
+    @Test
+    void shouldUpdateStock() {
+        Tool tool = createMockTool();
+        ToolStockRequest stockRequest = new ToolStockRequest();
+        stockRequest.setAvailable(7);
+        stockRequest.setDamaged(2);
+        stockRequest.setOnLoan(1);
+
+        when(toolRepository.findById(1L)).thenReturn(Optional.of(tool));
+        when(toolRepository.save(any())).thenReturn(tool);
+        when(toolMapper.toResponse(tool)).thenReturn(new ToolResponse());
+
+        ToolResponse response = toolService.updateStock(1L, stockRequest);
+
+        assertThat(response).isNotNull();
+        verify(toolRepository).save(toolCaptor.capture());
+        Tool captured = toolCaptor.getValue();
+        assertThat(captured.getQuantity()).isEqualTo(10);
+        assertThat(captured.getAvailable()).isEqualTo(7);
+    }
+
+    @Test
+    void shouldThrowWhenNoAuthenticatedUserFound() {
+        SecurityContextHolder.clearContext(); // Limpia el contexto para simular sesión vacía
+
+        ToolServiceImpl serviceWithoutUser = new ToolServiceImpl(
+                toolRepository, categoryService, toolMapper
+        );
+
+        assertThatThrownBy(serviceWithoutUser::getCurrentUserId)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("No authenticated user found.");
+    }
+
+    @Test
+    void shouldThrowWhenPrincipalIsNotUserLogin() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("not-a-userlogin", null)
+        );
+
+        ToolServiceImpl service = new ToolServiceImpl(
+                toolRepository, categoryService, toolMapper
+        );
+
+        assertThatThrownBy(service::getCurrentUserId)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("No authenticated user found.");
+    }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive implementation for managing tools and categories in the system. It includes new REST controllers, DTOs, mappers, and persistence entities for both tools and categories, providing CRUD operations and additional features like filtering, validation, and stock management.

### Controllers
* **`CategoryController`**: Implements an endpoint to retrieve all categories with role-based access control and Swagger documentation for API responses.
* **`ToolController`**: Adds endpoints for creating, updating, deleting, and retrieving tools, as well as managing tool stock. Supports pagination, filtering, and Swagger documentation.

### DTOs
* **`CategoryResponse`**: Defines the response structure for category data, including fields like `id`, `name`, `status`, and timestamps.
* **`ToolRequest`**: Represents the payload for creating or updating tools, with validation annotations for fields like `toolName`, `brand`, and `category`.
* **`ToolResponse`**: Specifies the response structure for tool data, including inventory details and associated category information.
* **`ToolStockRequest`**: Introduces a DTO for updating stock-related fields of tools, such as `available`, `damaged`, and `onLoan`.

### Mappers
* **`CategoryMapper`**: Converts between `Category` entities and `CategoryResponse` DTOs using MapStruct.
* **`ToolMapper`**: Maps `ToolRequest` to `Tool` entities and `Tool` entities to `ToolResponse` DTOs, with specific fields ignored during mapping.

### Persistence Entities
* **`Category`**: Represents a tool category in the database, with fields for metadata, status, and relationships to tools. Includes a one-to-many relationship with the `Tool` entity.…ng and mapping