### PR TITLE
Rename migration script V1_0_4_create_loan.sql.

### DIFF
--- a/src/main/resources/db/migration/V1_0_4__create_loan.sql
+++ b/src/main/resources/db/migration/V1_0_4__create_loan.sql
@@ -1,8 +1,3 @@
--- Secuencia para la tabla 'loan'
-CREATE SEQUENCE IF NOT EXISTS loan_id_seq
-    START WITH 1
-    INCREMENT BY 1;
-
 -- Tabla 'loan'
 CREATE TABLE IF NOT EXISTS loan
 (
@@ -19,10 +14,10 @@ CREATE TABLE IF NOT EXISTS loan
     updated_by     BIGINT    NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (teacher_id) REFERENCES toolflow_user (id)
-);
+    );
 
--- Secuencia para la tabla 'loan_tool'
-CREATE SEQUENCE IF NOT EXISTS loan_tool_id_seq
+-- Secuencia para la tabla 'loan'
+CREATE SEQUENCE IF NOT EXISTS loan_id_seq
     START WITH 1
     INCREMENT BY 1;
 
@@ -42,4 +37,9 @@ CREATE TABLE IF NOT EXISTS loan_tool
     FOREIGN KEY (loan_id) REFERENCES loan (id) ON DELETE CASCADE,
     FOREIGN KEY (tool_id) REFERENCES tool (id),
     FOREIGN KEY (responsible_id) REFERENCES toolflow_user (id)
-);
+    );
+
+-- Secuencia para la tabla 'loan_tool'
+CREATE SEQUENCE IF NOT EXISTS loan_tool_id_seq
+    START WITH 1
+    INCREMENT BY 1;


### PR DESCRIPTION
This pull request makes adjustments to the database migration script to reorganize and correct the placement of sequence creation statements for the `loan` and `loan_tool` tables. Additionally, the file was renamed for consistency in naming conventions.

### Database migration script updates:

* **File Renaming**: Renamed `src/main/resources/db/migration/V1_0_4_create_loan.sql` to `src/main/resources/db/migration/V1_0_4__create_loan.sql` to align with consistent naming conventions.

* **Reordering of Sequence Creation for `loan` Table**: Moved the creation of the `loan_id_seq` sequence to appear after the `loan` table definition instead of before it.

* **Addition of Sequence for `loan_tool` Table**: Added the `loan_tool_id_seq` sequence definition after the `loan_tool` table creation to ensure proper sequence initialization.