### PR TITLE
Add student upload functionality with Excel file support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,16 @@
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.8.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi</artifactId>
+			<version>5.4.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi-ooxml</artifactId>
+			<version>5.4.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/codeflow/toolflow/controller/user/UserController.java
+++ b/src/main/java/com/codeflow/toolflow/controller/user/UserController.java
@@ -25,6 +25,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -289,5 +290,28 @@ public class UserController {
             @RequestParam List<Role> roles) {
         List<UserResponse> users = userService.findByRoles(roles);
         return ResponseEntity.ok(users);
+    }
+
+    @Operation(
+            summary = "Upload Students",
+            description = "Uploads a list of students from a file. The file should contain user details in a specific format.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "File containing student data",
+                    content = @Content(
+                            mediaType = "multipart/form-data",
+                            schema = @Schema(type = "string", format = "binary")
+                    )
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Students uploaded successfully"),
+                    @ApiResponse(responseCode = "400", description = "Invalid file format or content", content = @Content(schema = @Schema(implementation = ApiError.class))),
+                    @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(schema = @Schema(implementation = ApiError.class)))
+            }
+    )
+    @PostMapping("/upload-students")
+    @PreAuthorize("hasRole('ADMINISTRATOR')")
+    public ResponseEntity<Void> uploadStudents(@RequestParam("file") MultipartFile file) {
+        userService.uploadStudents(file);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/codeflow/toolflow/persistence/user/repository/UserSpecifications.java
+++ b/src/main/java/com/codeflow/toolflow/persistence/user/repository/UserSpecifications.java
@@ -1,7 +1,10 @@
 package com.codeflow.toolflow.persistence.user.repository;
 
 import com.codeflow.toolflow.persistence.user.entity.User;
+import com.codeflow.toolflow.util.enums.Role;
 import com.codeflow.toolflow.util.exception.InvalidSearchColumnException;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.util.Arrays;
@@ -38,6 +41,13 @@ public class UserSpecifications {
         }
         return (root, query, cb) ->
                 cb.like(cb.lower(root.get(column)), "%" + search.toLowerCase() + "%");
+    }
+
+    public static Specification<User> hasRole(String roleName) {
+        return (root, query, criteriaBuilder) -> {
+            Join<Object, Object> roleJoin = root.join("userRoles", JoinType.INNER);
+            return criteriaBuilder.equal(roleJoin.get("role"), Role.valueOf(roleName));
+        };
     }
 }
 

--- a/src/main/java/com/codeflow/toolflow/service/user/UserService.java
+++ b/src/main/java/com/codeflow/toolflow/service/user/UserService.java
@@ -6,6 +6,7 @@ import com.codeflow.toolflow.persistence.user.entity.User;
 import com.codeflow.toolflow.util.enums.Role;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Optional;
@@ -81,4 +82,11 @@ public interface UserService {
      * @return a {@code List<UserResponse>} containing users and their roles.
      */
     List<UserResponse> findByRoles(List<Role> roles);
+
+    /**
+     * Uploads a list of students from a file.
+     *
+     * @param file the file containing student data to be uploaded.
+     */
+    void uploadStudents(MultipartFile file);
 }

--- a/src/main/java/com/codeflow/toolflow/service/user/impl/UserServiceImpl.java
+++ b/src/main/java/com/codeflow/toolflow/service/user/impl/UserServiceImpl.java
@@ -15,6 +15,7 @@ import com.codeflow.toolflow.util.exception.InvalidRoleAssignmentException;
 import com.codeflow.toolflow.util.exception.UserAlreadyExistsException;
 import com.codeflow.toolflow.util.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -22,6 +23,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.*;
@@ -150,7 +152,9 @@ public class UserServiceImpl implements UserService {
     public Page<UserResponse> getPage(Pageable pageable, String search, String searchColumn) {
         Specification<User> spec = Specification.where(UserSpecifications.userIsActive());
 
-        if (StringUtils.hasText(search) && StringUtils.hasText(searchColumn)) {
+        if (StringUtils.hasText(searchColumn) && searchColumn.equalsIgnoreCase("role")) {
+            spec = spec.and(UserSpecifications.hasRole(search));
+        } else if (StringUtils.hasText(search) && StringUtils.hasText(searchColumn)) {
             spec = spec.and(UserSpecifications.searchByColumn(searchColumn, search));
         }
 
@@ -243,6 +247,78 @@ public class UserServiceImpl implements UserService {
                 .toList();
     }
 
+    /**
+     * Uploads a list of students from an Excel file.
+     * Each row in the file is processed to create a new user with the provided details.
+     * If a user with the same document already exists, it skips that row.
+     *
+     * @param file the Excel file containing student data.
+     */
+    @Override
+    public void uploadStudents(MultipartFile file) {
+        try (Workbook workbook = WorkbookFactory.create(file.getInputStream())) {
+            Sheet sheet = workbook.getSheetAt(0);
+
+            for (int i = 1; i <= sheet.getLastRowNum(); i++) {
+                Row row = sheet.getRow(i);
+                if (row == null) continue;
+
+                String document = getCellValue(row, 6);
+                String name = getCellValue(row, 1);
+                String lastName = getCellValue(row, 3);
+                String email = getCellValue(row, 9);
+                String phone = getCellValue(row, 8);
+
+                if (document.isBlank() || name.isBlank()) {
+                    System.out.println("Fila " + i + " inválida: documento o nombre vacío.");
+                    continue;
+                }
+
+                if (userRepository.findByUsername(document).isPresent()) {
+                    System.out.println("Duplicado (documento): " + document);
+                    continue;
+                }
+
+                UserRequest request = new UserRequest();
+                request.setUsername(document);
+                request.setName(name);
+                request.setLastName(lastName);
+                request.setEmail(email);
+                request.setPhone(phone);
+                request.setPassword(UUID.randomUUID().toString());
+                request.setRepeatedPassword(request.getPassword());
+                request.setRoles(List.of(Role.STUDENT));
+
+                try {
+                    registerOneUser(request);
+                } catch (Exception e) {
+                    System.err.println("Error fila " + i + ": " + e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Error al procesar el archivo: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Retrieves the value of a cell in a row based on the specified index.
+     * Handles different cell types (String, Numeric, Boolean) and returns an empty string for null cells.
+     *
+     * @param row   the row containing the cell
+     * @param index the index of the cell to retrieve
+     * @return the trimmed string value of the cell, or an empty string if the cell is null
+     */
+    private String getCellValue(Row row, int index) {
+        Cell cell = row.getCell(index);
+        if (cell == null) return "";
+
+        return switch (cell.getCellType()) {
+            case STRING -> cell.getStringCellValue().trim();
+            case NUMERIC -> String.valueOf((long) cell.getNumericCellValue()); // evita "12345.0"
+            case BOOLEAN -> String.valueOf(cell.getBooleanCellValue());
+            default -> "";
+        };
+    }
     /**
      * Retrieves a user by id or throws an exception if not found.
      *


### PR DESCRIPTION
This pull request introduces functionality for uploading student data from Excel files, enhances search capabilities based on user roles, and adds dependencies for Apache POI to handle Excel file processing. The most significant changes include the addition of the `uploadStudents` method, updates to the search specifications, and modifications to the `UserController` to expose the new upload endpoint.

### Excel File Upload Functionality:
* **New method in `UserServiceImpl`:** Added `uploadStudents` to process Excel files, create new users, and skip duplicates. Includes helper method `getCellValue` for reading cell data.
* **Controller endpoint:** Introduced `/upload-students` endpoint in `UserController` for uploading student data files. Includes OpenAPI documentation and role-based access control.
* **Dependencies:** Added Apache POI libraries (`poi` and `poi-ooxml`) to `pom.xml` for Excel file handling.

### Enhanced Search Capabilities:
* **Role-based search specification:** Added `hasRole` method in `UserSpecifications` to filter users by roles using JPA criteria queries.
* **Search logic update:** Modified search functionality in `UserServiceImpl` to integrate role-based filtering.

### Miscellaneous Updates:
* **Interface changes:** Updated `UserService` to declare the `uploadStudents` method.
* **Imports:** Added necessary imports for `MultipartFile` and Apache POI classes across relevant files. [[1]](diffhunk://#diff-84847731fc02b08f6efdb1720b64334b39d10a08b46501abf6f78491909d244dR28) [[2]](diffhunk://#diff-1804db1f4314f68cb5b0713b76fbfc4a5c00789824e859564033d5c80cc7f6c0R9) [[3]](diffhunk://#diff-8ade639f69ce13bb01078878ad9ae833e818b7d4bc11fd87f0a1cfd4a5ff02f5R18-R26)