### PR TITLE
Add functionality to retrieve tools by headquarter with simplified re…

### DIFF
--- a/src/main/java/com/codeflow/toolflow/controller/tool/ToolController.java
+++ b/src/main/java/com/codeflow/toolflow/controller/tool/ToolController.java
@@ -229,4 +229,46 @@ public class ToolController {
         ToolResponse updated = toolService.updateStockByHeadquarter(toolId, headquarterId, toolStockRequest);
         return ResponseEntity.ok(updated);
     }
+
+    @GetMapping("/headquarters/{headquarterId}/tools")
+    @PreAuthorize("hasAnyRole('ADMINISTRATOR', 'TOOL_ADMINISTRATOR', 'TEACHER')")
+    @Operation(
+            summary = "Get tools by headquarter",
+            description = "Returns a simplified list of tools belonging to a specific headquarter, including only ID, name, and available quantity.",
+            parameters = {
+                    @Parameter(
+                            name = "headquarterId",
+                            in = ParameterIn.PATH,
+                            description = "Headquarter ID to filter tools",
+                            required = true,
+                            example = "1"
+                    )
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Tools retrieved successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = ToolSimpleResponse.class))
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Headquarter not found",
+                    content = @Content(schema = @Schema(implementation = ApiError.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access denied",
+                    content = @Content(schema = @Schema(implementation = ApiError.class))
+            )
+    })
+    public ResponseEntity<List<ToolSimpleResponse>> getToolsByHeadquarter(
+            @PathVariable Long headquarterId) {
+        List<ToolSimpleResponse> tools = toolService.getToolsByHeadquarter(headquarterId);
+        return ResponseEntity.ok(tools);
+    }
+
 }

--- a/src/main/java/com/codeflow/toolflow/dto/tool/ToolSimpleResponse.java
+++ b/src/main/java/com/codeflow/toolflow/dto/tool/ToolSimpleResponse.java
@@ -1,0 +1,41 @@
+package com.codeflow.toolflow.dto.tool;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * Data Transfer Object (DTO) representing a simplified response data for a tool,
+ * useful for selects or lightweight listings.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ToolSimpleResponse implements Serializable {
+
+    /**
+     * The unique identifier of the tool.
+     */
+    private Long id;
+
+    /**
+     * The name of the tool.
+     */
+    private String toolName;
+
+    /**
+     * The number of units currently available for use.
+     */
+    private Integer available;
+
+}

--- a/src/main/java/com/codeflow/toolflow/mapper/tool/ToolMapper.java
+++ b/src/main/java/com/codeflow/toolflow/mapper/tool/ToolMapper.java
@@ -2,7 +2,9 @@ package com.codeflow.toolflow.mapper.tool;
 
 import com.codeflow.toolflow.dto.tool.ToolRequest;
 import com.codeflow.toolflow.dto.tool.ToolResponse;
+import com.codeflow.toolflow.dto.tool.ToolSimpleResponse;
 import com.codeflow.toolflow.persistence.tool.entity.Tool;
+import com.codeflow.toolflow.persistence.tool.entity.ToolInventory;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -16,7 +18,7 @@ public interface ToolMapper {
     @Mapping(target = "updatedAt", ignore = true)
     @Mapping(target = "updatedBy", ignore = true)
     @Mapping(target = "category", ignore = true)
-    Tool toNewEntity(ToolRequest dto); // se usa en CREATE
+    Tool toNewEntity(ToolRequest dto);
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
@@ -28,5 +30,13 @@ public interface ToolMapper {
     @Mapping(target = "available", ignore = true)
     @Mapping(target = "onLoan", ignore = true)
     @Mapping(target = "damaged", ignore = true)
-    Tool toExistingEntity(ToolRequest dto); // se usa en UPDATE
+    Tool toExistingEntity(ToolRequest dto);
+
+    /**
+     * Maps Tool and ToolInventory into ToolSimpleResponse.
+     */
+    @Mapping(target = "id", source = "tool.id")
+    @Mapping(target = "toolName", source = "tool.toolName")
+    @Mapping(target = "available", source = "inventory.available")
+    ToolSimpleResponse toSimpleResponse(Tool tool, ToolInventory inventory);
 }

--- a/src/main/java/com/codeflow/toolflow/service/tool/ToolService.java
+++ b/src/main/java/com/codeflow/toolflow/service/tool/ToolService.java
@@ -2,6 +2,7 @@ package com.codeflow.toolflow.service.tool;
 
 import com.codeflow.toolflow.dto.tool.ToolRequest;
 import com.codeflow.toolflow.dto.tool.ToolResponse;
+import com.codeflow.toolflow.dto.tool.ToolSimpleResponse;
 import com.codeflow.toolflow.dto.tool.ToolStockRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -71,4 +72,12 @@ public interface ToolService {
      * @return a list of {@link ToolResponse} objects representing each tool
      */
     List<ToolResponse> getAll();
+
+    /**
+     * Retrieves a list of tools associated with a specific headquarter.
+     *
+     * @param headquarterId the ID of the headquarter
+     * @return a list of {@link ToolSimpleResponse} objects representing the tools
+     */
+    List<ToolSimpleResponse> getToolsByHeadquarter(Long headquarterId);
 }

--- a/src/main/java/com/codeflow/toolflow/service/tool/impl/ToolServiceImpl.java
+++ b/src/main/java/com/codeflow/toolflow/service/tool/impl/ToolServiceImpl.java
@@ -3,6 +3,7 @@ package com.codeflow.toolflow.service.tool.impl;
 import com.codeflow.toolflow.dto.auth.UserLogin;
 import com.codeflow.toolflow.dto.tool.ToolRequest;
 import com.codeflow.toolflow.dto.tool.ToolResponse;
+import com.codeflow.toolflow.dto.tool.ToolSimpleResponse;
 import com.codeflow.toolflow.dto.tool.ToolStockRequest;
 import com.codeflow.toolflow.mapper.tool.ToolMapper;
 import com.codeflow.toolflow.persistence.tool.entity.Tool;
@@ -402,6 +403,37 @@ public class ToolServiceImpl implements ToolService {
             emailService.sendHtmlEmail(adminEmail, subject, htmlBody);
         }
     }
+
+    /**
+     * Retrieves a list of tools available in a specific headquarter.
+     * This method filters tools based on their active status and checks
+     * for inventory in the specified headquarter.
+     *
+     * @param headquarterId the ID of the headquarter to filter tools by
+     * @return a list of {@link ToolSimpleResponse} objects representing available tools
+     */
+    @Override
+    public List<ToolSimpleResponse> getToolsByHeadquarter(Long headquarterId) {
+        List<Tool> tools = toolRepository.findAll(Specification.where(ToolSpecifications.toolIsActive()));
+
+        List<ToolSimpleResponse> result = new ArrayList<>();
+
+        for (Tool tool : tools) {
+            Optional<ToolInventory> inventoryOpt = tool.getInventories().stream()
+                    .filter(inv -> inv.getHeadquarter().getId().equals(headquarterId))
+                    .findFirst();
+
+            if (inventoryOpt.isPresent()) {
+                ToolInventory inventory = inventoryOpt.get();
+
+                ToolSimpleResponse dto = toolMapper.toSimpleResponse(tool, inventory);
+                result.add(dto);
+            }
+        }
+
+        return result;
+    }
+
 
     private String buildLowStockHtmlBody(Tool tool) {
         StringBuilder html = new StringBuilder();


### PR DESCRIPTION
This pull request introduces a new feature to retrieve a simplified list of tools by headquarter and includes supporting changes across the controller, service, mapper, and DTO layers. The most important changes involve adding the new endpoint, defining the DTO for the response, implementing the service logic, and updating the mapper to handle the transformation.

### New Feature: Retrieve Tools by Headquarter

#### Controller Updates:
* Added `getToolsByHeadquarter` endpoint in `ToolController` to retrieve a simplified list of tools for a specific headquarter, including their ID, name, and available quantity. The endpoint includes role-based access control and API documentation annotations.

#### DTO Definition:
* Created `ToolSimpleResponse` DTO to represent lightweight tool information, including fields for ID, name, and available quantity. This DTO is used for the new endpoint's response.

#### Service Implementation:
* Added `getToolsByHeadquarter` method in `ToolServiceImpl` to fetch tools based on their active status and inventory availability at the specified headquarter. The method uses `ToolMapper` to map entities to the `ToolSimpleResponse` DTO.

#### Mapper Updates:
* Updated `ToolMapper` with a new mapping method `toSimpleResponse` to transform `Tool` and `ToolInventory` entities into `ToolSimpleResponse` DTOs.…sponse